### PR TITLE
Base compiler >= 4.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OCaml Websocket library for [http/af](https://github.com/inhabitedtype/httpaf)
 
-*Note*: requires a locally pinned version of http/af with
-[this patch](https://github.com/inhabitedtype/httpaf/pull/66).
+*Note*: requires an up-to-date version of http/af with [this
+patch](https://github.com/inhabitedtype/httpaf/pull/66).
 
 WIP
 

--- a/lib/websocket_httpaf_intf.ml
+++ b/lib/websocket_httpaf_intf.ml
@@ -5,7 +5,7 @@ module type Websocket_httpaf = sig
   include module type of struct include Websocket end
 
   val upgrade_connection : ?headers:Httpaf.Headers.t ->
-                           'handle Httpaf.Reqd.t ->
+                           Httpaf.Reqd.t ->
                            file_descr ->
                            (Websocket.Frame.t -> unit) ->
                            (Httpaf.Response.t * [ `write ] Httpaf.Body.t *

--- a/websocket-httpaf-async.opam
+++ b/websocket-httpaf-async.opam
@@ -1,6 +1,8 @@
 opam-version: "2.0"
 maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
 authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+synopsis: "Websocket HTTP/AF async"
+description: "Websocket HTTP/AF async"
 license: "MIT"
 homepage: "https://github.com/anmonteiro/websocket-httpaf"
 dev-repo: "git+https://github.com/anmonteiro/websocket-httpaf.git"
@@ -9,10 +11,10 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03.0" & < "4.08.0"}
-  "dune" {build}
-  "async_kernel" {>= "v0.11.0"}
-  "async_unix" {>= "v0.11.0"}
+  "ocaml" { >= "4.08.0"}
+  "dune" {build & >= "1.11"}
+  "async_kernel" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0"}
   "base"
   "fmt"
   "logs"

--- a/websocket-httpaf-async.opam
+++ b/websocket-httpaf-async.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.08.0"}
-  "dune" {build & >= "1.11"}
+  "dune" {build & >= "1.7"}
   "async_kernel" {>= "v0.13.0"}
   "async_unix" {>= "v0.13.0"}
   "base"

--- a/websocket-httpaf-lwt.opam
+++ b/websocket-httpaf-lwt.opam
@@ -1,6 +1,8 @@
 opam-version: "2.0"
 maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
 authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+synopsis: "Websocket HTTP/AF Lwt"
+description: "Websocket HTTP/AF Lwt"
 license: "MIT"
 homepage: "https://github.com/anmonteiro/websocket-httpaf"
 dev-repo: "git+https://github.com/anmonteiro/websocket-httpaf.git"
@@ -9,8 +11,8 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03.0" & < "4.08.0"}
-  "dune" {build}
+  "ocaml" { >= "4.08.0"}
+  "dune" {build & >= "1.11"}
   "logs"
   "lwt"
   "websocket-httpaf"

--- a/websocket-httpaf-lwt.opam
+++ b/websocket-httpaf-lwt.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.08.0"}
-  "dune" {build & >= "1.11"}
+  "dune" {build & >= "1.7"}
   "logs"
   "lwt"
   "websocket-httpaf"

--- a/websocket-httpaf.opam
+++ b/websocket-httpaf.opam
@@ -1,6 +1,8 @@
 opam-version: "2.0"
 maintainer: "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
 authors: [ "Antonio Nuno Monteiro <anmonteiro@gmail.com>" ]
+synopsis: "Websocket HTTP/AF"
+description: "Websocket HTTP/AF"
 license: "MIT"
 homepage: "https://github.com/anmonteiro/websocket-httpaf"
 dev-repo: "git+https://github.com/anmonteiro/websocket-httpaf.git"
@@ -9,8 +11,8 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03.0" & < "4.08.0"}
-  "jbuilder" {build}
-  "httpaf"
+  "ocaml" { >= "4.08.0"}
+  "dune" {build & >= "1.11"}
+  "httpaf" { >= "0.6.5" }
   "websocket"
 ]

--- a/websocket-httpaf.opam
+++ b/websocket-httpaf.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.08.0"}
-  "dune" {build & >= "1.11"}
-  "httpaf" { >= "0.6.5" }
+  "dune" {build & >= "1.7"}
+  "httpaf" { >= "0.6.0" }
   "websocket"
 ]


### PR DESCRIPTION
I've updated the compiler dependency and corrected the README note about the `httpaf` dependency since the required patch has been incorporated into a version released through `opam`.